### PR TITLE
build: create Ansible configuration

### DIFF
--- a/ansible/cepad.yml
+++ b/ansible/cepad.yml
@@ -1,0 +1,9 @@
+---
+# This playbook deploys the `cepad` module on all hosts
+
+- hosts: all
+  roles:
+    - prepare-node
+    - git-clone-module
+
+# TODO: Deploy application code

--- a/ansible/roles/git-clone-module/tasks/main.yml
+++ b/ansible/roles/git-clone-module/tasks/main.yml
@@ -1,0 +1,90 @@
+---
+# tasks/main.yml   
+- name: Check if ssh key is already present
+  stat:
+    path: "{{ KEY_PATH }}"
+  register: key_stat_result
+
+- name: Generate SSH key for accessing GitHub
+  command: "ssh-keygen -t rsa -f {{ KEY_PATH }} -N ''"
+  when: not key_stat_result.stat.exists
+
+- name: Get key content
+  command: "cat {{ KEY_PATH }}.pub"
+  register: key_content
+
+
+- name: Check if known_host exists
+  stat:
+    path: "{{ KNOWN_HOSTS_PATH }}"
+  register: known_hosts_stat
+
+- name: Create known_hosts if it doesn't exist
+  file:
+    path: "{{ KNOWN_HOSTS_PATH }}"
+    state: touch
+  when: not known_hosts_stat.stat.exists
+
+- name: Get the content of known hosts
+  shell: "cat {{ KNOWN_HOSTS_PATH }} | grep {{ GIT_SERVER_FQDN }}"
+  register: host_stat
+  failed_when: host_stat.rc > 1
+
+
+- name: Modify known hosts
+  block:
+  - name: Fetch GitHub public key
+    command: "ssh-keyscan -T 10 {{ GIT_SERVER_FQDN }}"
+    register: keyscan
+
+  - name: Add GitHub public key to ssh known_hosts
+    lineinfile:
+      path: "{{ KNOWN_HOSTS_PATH }}"
+      create: yes
+      line: "{{ item }}"
+    with_items: '{{ keyscan.stdout_lines }}'
+  when: host_stat.rc == 1
+
+- name: Get hostname
+  command: hostname
+  register: hostname_result
+
+- name: Add SSH public key to GitHub account
+  uri:
+    url: "https://api.{{ GIT_SERVER_FQDN }}/user/keys"
+    validate_certs: no
+    method: POST
+    body:
+      title: "{{ KEY_TITLE }}_{{ hostname_result.stdout  }}"
+      key: "{{ key_content.stdout }}"
+    body_format: json
+    headers:
+      Content-Type: "application/json"
+      Authorization: "token {{ GITHUB_ACCESS_TOKEN }}"
+    status_code:
+    - 201
+    - 422
+
+- name: Configure SSH agent and clone repository
+  block:
+  - name: Remove old repository
+    file:
+      path: "{{ CLONE_DEST }}"
+      state: absent
+
+  - name: Add SSH key to SSH agent
+    shell: |
+      eval $(ssh-agent -s)
+      ssh-add {{ KEY_PATH }}
+
+  - name: Clone the repository
+    shell: GIT_SSH_COMMAND="ssh -i {{ KEY_PATH }} -v -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" {{ GIT_EXECUTABLE }} clone {{ GIT_REPO }} {{ CLONE_DEST }}
+  
+  - name: Switch branch 
+    shell: "{{ GIT_EXECUTABLE }} checkout {{ GIT_BRANCH }}"
+    args:
+      chdir: "{{ CLONE_DEST }}"
+
+  always:
+  - name: Kill the ssh-agent
+    shell: export pid=`ps -A | grep ssh-agent | awk 'NR==1{print $1}' | cut -d' ' -f1`; kill $pid

--- a/ansible/roles/git-clone-module/vars/main.yml
+++ b/ansible/roles/git-clone-module/vars/main.yml
@@ -1,0 +1,34 @@
+# Name of the SSH key (e.g. git_ssh_key)
+KEY_TITLE: git_ssh
+
+# Location of the SSH key to be (e.g. ~/.ssh/id_rsa_git)
+KEY_PATH: ~/.ssh/id_ed25519
+
+# Git repository to be cloned. Must be SSH (not https)
+GIT_REPO: git@github.com:diegonyc/cepad.git
+
+# Branch of the git repository (e.g. master)
+GIT_BRANCH: main
+
+# Directory where the repository will be cloned (e.g. /home/user/repo_name)
+CLONE_DEST: ~/cepad
+
+# Location of the SSH known hosts file (e.g. ~/.ssh/known_hosts)
+KNOWN_HOSTS_PATH: ~/.ssh/known_hosts
+
+# Location of the git binary (e.g. /usr/bin/git)
+GIT_EXECUTABLE: /usr/bin/git
+
+# Github FQDN
+GIT_SERVER_FQDN: github.com
+
+# GitHub personal access token
+# (e.g. GITHUB_ACCESS_TOKEN: <Encrypted Token>)
+GITHUB_ACCESS_TOKEN: !vault |
+          $ANSIBLE_VAULT;1.1;AES256
+          37633736373463396261346332666532646337636538666435313935663932366132373130336633
+          3663393836613935363432323639333131393165633739610a383539316335323535653663356236
+          33663831333435383764313130326166313937316461333435336162343334346135343632363636
+          3163363562633433370a313135316139656437376662636164306630383338626337383130356564
+          34336562646263666538343132323231396232663138326162653133376366393335663036393263
+          6439373135353936663037323330366165386630373439613934

--- a/ansible/roles/prepare-node/tasks/main.yml
+++ b/ansible/roles/prepare-node/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# This playbook contains plays that will prepare a node to run the `ai` module
+- name: Install required system packages
+  apt: name={{ item }} state=latest update_cache=yes
+  loop: [ 'apt-transport-https', 'ca-certificates', 'curl', 'software-properties-common', 'python3-pip', 'virtualenv', 'python3-setuptools']
+
+- name: Add Nvidia Container Toolkit apt GPG key
+  apt_key:
+    url: https://nvidia.github.io/nvidia-docker/gpgkey
+    state: present
+- name: Add Nvidia Container Toolkit Repository
+  apt_repository:
+    repo: "{{ item }}"
+    state: present
+  with_items:
+    - "deb https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/amd64 /"
+    - "deb https://nvidia.github.io/nvidia-container-runtime/stable/ubuntu18.04/amd64 /"
+    - "deb https://nvidia.github.io/nvidia-docker/ubuntu18.04/amd64 /"
+- name: Install Nvidia Container Toolkit
+  apt: update_cache=yes name=nvidia-docker2 state=latest
+
+- name: Add Docker apt GPG Key
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
+- name: Add Docker Repository
+  apt_repository:
+    repo: deb https://download.docker.com/linux/ubuntu bionic stable
+    state: present
+- name: Update apt and install docker-ce
+  apt: update_cache=yes name=docker-ce state=latest
+- name: Restart Docker service
+  service: name=docker state=restarted enabled=yes


### PR DESCRIPTION
# Summary

Creates an Ansible Playbook that configures and clones the `cepad` repository from a worker node. Eventually, the playbook will contain the full configuration to go from configuration to deployment. It may look something like this:

```yaml
# playbook.yml
- hosts: all
  roles:
    - prepare-node
    - git-clone-module
    - ai-worker

```