### PR TITLE
build: run cepad docker image

### DIFF
--- a/ansible/cepad.yml
+++ b/ansible/cepad.yml
@@ -5,4 +5,4 @@
   roles:
     - { role: prepare-node, tags: ['configuration'] }
     - { role: git-clone-module, tags: ['configuration'] }
-    - { role: cepad-worker, tags: ['build'] }
+    - { role: cepad-worker, tags: ['application'] }

--- a/ansible/cepad.yml
+++ b/ansible/cepad.yml
@@ -3,7 +3,6 @@
 
 - hosts: all
   roles:
-    - prepare-node
-    - git-clone-module
-
-# TODO: Deploy application code
+    - { role: prepare-node, tags: ['configuration'] }
+    - { role: git-clone-module, tags: ['configuration'] }
+    - { role: cepad-worker, tags: ['build'] }

--- a/ansible/roles/cepad-worker/tasks/main.yml
+++ b/ansible/roles/cepad-worker/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Install Docker Python package
+  pip:
+    name: docker
+- name: Build cepad image
+  community.docker.docker_image:
+    name: cepad
+    tag: latest
+    push: no
+    source: build
+    build:
+      path: ~/cepad
+# This is necessary so that cepad works
+- name: Start Redis
+  community.docker.docker_container:
+    name: redis
+    image: redis
+    state: started
+    restart: yes
+    network_mode: host
+    exposed_ports:
+      - 6379
+  
+- name: Start container
+  community.docker.docker_container:
+    name: cepad
+    image: "cepad:latest"
+    state: started
+    restart: yes
+    network_mode: host


### PR DESCRIPTION
# Summary

Adds a `cepad-worker` Ansible role. The role simply has a task: (1) installs the Docker Python package, since it's a requirement for the `docker` ansible module; (2) builds the `cepad` image given the latest `Dockerfile` from the cloned repo; (3) starts two containers—redis and cepad—running the whole application.

I also added tags since the first two roles can be slow to finish. If you have pre-configured nodes (you have already ran the tasks with the tag `configuration`), you can build and run the application skipping those roles using the following command:

```shell
ansible-playbook cepad.yml --tags "build"
```